### PR TITLE
Add scheme validation to livebox address

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -85,6 +85,10 @@ func New(client *http.Client, address, username, password string) (*Client, erro
 		return nil, fmt.Errorf("failed to parse livebox address: %w", err)
 	}
 
+	if u.Scheme == "" {
+		return nil, errors.New("scheme is missing in livebox address")
+	}
+
 	u.Path = apiEndpoint
 
 	return &Client{


### PR DESCRIPTION
New client creation now checks if the scheme is present in the livebox address and returns an error if missing, preventing misconfigured URLs.

Should prevent https://github.com/Tomy2e/livebox-exporter/issues/24 from happening in the future.